### PR TITLE
Owner Reference replace for secret copies

### DIFF
--- a/pkg/manager/manager.go
+++ b/pkg/manager/manager.go
@@ -156,7 +156,7 @@ func SetOwnerRefForSecretCopies(secretNames []string, ownerRef []metav1.OwnerRef
 		if err != nil {
 			return err
 		}
-		secret.OwnerReferences = append(secret.OwnerReferences, ownerRef...)
+		secret.OwnerReferences = ownerRef
 		err = updateSecret(secret)
 		if err != nil {
 			return err


### PR DESCRIPTION
Owner reference must be replaced in order to remove old owner references if present